### PR TITLE
Revisions now store revised_attributes as deflated binary strings

### DIFF
--- a/lib/mongoidal/revision.rb
+++ b/lib/mongoidal/revision.rb
@@ -23,6 +23,7 @@ module Mongoidal
       # compressed version of revised attributes
       field :revised_attributes_c,type: BSON::Binary
       field :revised_embeds,      type: Hash, default: ->{{}}
+      field :event_data,          type: Hash, default: ->{{}}
 
       field :revised_keys,        type: Array
 

--- a/lib/mongoidal/revision.rb
+++ b/lib/mongoidal/revision.rb
@@ -1,3 +1,5 @@
+require "zlib"
+
 module Mongoidal
   module Revision
     extend ActiveSupport::Concern
@@ -14,12 +16,39 @@ module Mongoidal
       validates_uniqueness_of :number
 
       field :tag,                 type: String
+      field :type,                type: Symbol, default: :change
 
       field :message,             type: String
 
-      field :revised_attributes,  type: Hash, default: ->{{}}
+      # compressed version of revised attributes
+      field :revised_attributes_c,type: BSON::Binary
       field :revised_embeds,      type: Hash, default: ->{{}}
 
+      field :revised_keys,        type: Array
+
+      before_save :set_compressed
+
+      def set_compressed
+        self.revised_keys = revised_attributes.keys
+        compressed = Zlib::Deflate.deflate(JSON.dump(revised_attributes))
+        self.revised_attributes_c = BSON::Binary.new(compressed)
+        self[:revised_attributes] = nil if self[:revised_attributes]
+      end
+
+      def revised_attributes
+        @revised_attributes ||= begin
+          attr = self[:revised_attributes_c]
+          if attr.present?
+            JSON.parse(Zlib::Inflate.inflate(attr.data))
+          else
+            self[:revised_attributes] || {}
+          end
+        end
+      end
+
+      def revised_attributes=(val)
+        @revised_attributes = val || {}
+      end
     end
 
     def base_revision?

--- a/lib/mongoidal/version.rb
+++ b/lib/mongoidal/version.rb
@@ -1,3 +1,3 @@
 module Mongoidal
-  VERSION = "0.0.1"
+  VERSION = "0.1.0"
 end

--- a/mongoidal.gemspec
+++ b/mongoidal.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "mongoid-slug"
-  spec.add_development_dependency "mongoid", '~> 5.1.0'
+  spec.add_development_dependency "mongoid", '~> 5.4.0'
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "sidekiq"
   spec.add_development_dependency "globalid"

--- a/spec/revisable_spec.rb
+++ b/spec/revisable_spec.rb
@@ -30,6 +30,16 @@ describe Mongoidal::Revisable do
     end
   end
 
+  describe 'event type' do
+    subject { existing }
+    context 'when there are changes' do
+      it 'should save' do
+        existing.revise!(type: :event, tag: 'clicked', event_data: {path: 'test'})
+        expect(existing.reload.revisions[1].event_data['path']).to eq 'test'
+      end
+    end
+  end
+
   describe '#revised_embed_changes' do
     subject { existing }
     context 'when there are changes' do

--- a/spec/revisable_spec.rb
+++ b/spec/revisable_spec.rb
@@ -23,6 +23,10 @@ describe Mongoidal::Revisable do
     context 'when there are changes' do
       before { existing.name = 'a' }
       its(:revised_changes) { should eq ({"name" => ["test", "a"]}) }
+
+      it 'should save' do
+        existing.revise!
+      end
     end
   end
 

--- a/spec/revision_spec.rb
+++ b/spec/revision_spec.rb
@@ -5,17 +5,34 @@ describe Revision do
   let(:embedded) { example.revisable_embedded_examples.create(name: 'a') }
   let(:user) { User.create }
 
-  before do
-    embedded.name = 'b'
-    example.name = 'b'
-    example.valid?
-    example.revise!
-    example.name = 'c'
-    example.revise!
+  describe 'embedded revisions' do
+    before do
+      example.name = 'b'
+      example.valid?
+      example.revise!
+      example.revise!
+    end
+
+    it 'should have stored revisions' do
+      expect(example.revisions.length).to eq 2
+      expect(example.revisions[1].revised_attributes['name']).to eq 'b'
+      expect(example.reload.revisions[1].revised_attributes['name']).to eq 'b'
+    end
   end
 
-  it 'should have stored revisions' do
-    expect(example.revisions.length).to eq 3
+  describe 'embedded revisions' do
+    before do
+      embedded.name = 'b'
+      example.name = 'b'
+      example.valid?
+      example.revise!
+      example.name = 'c'
+      example.revise!
+    end
+
+    it 'should have stored revisions' do
+      expect(example.revisions.length).to eq 3
+    end
   end
 
   # TODO: migrate other specs from main app

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,4 +1,3 @@
-
 class RevisableExample
   include Mongoidal::RootDocument
   include Mongoidal::Revisable


### PR DESCRIPTION
- Saves space on large documents
- also now supports using revisions to store events